### PR TITLE
Update GitHub package information

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chromaui/storybook-addon-pseudo-states.git"
+    "url": "git+https://github.com/rjlg/storybook-addon-pseudo-states.git"
   },
   "publishConfig": {
     "access": "public"
   },
-  "author": "Chromatic <support@chromatic.com>",
+  "author": "Rory",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Update `package.json` to prepare for publishing to own GitHub package.

* Change `repository.url` to `git+https://github.com/rjlg/storybook-addon-pseudo-states.git`
* Change `author` field to "Rory"
